### PR TITLE
Removed unnecessary duplicate of a submake from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,6 @@ clean:
 %.o: %.S
 	$(AS) -o $@ -c $< $(GFLAGS) $(ASFLAGS)
 
-dirs:
-	mkdir -p bin
-
 bootsect: $(BOOTSECT_OBJS)
 	$(LD) -o ./bin/$(BOOTSECT) $^ -Ttext 0x7C00 --oformat=binary
 


### PR DESCRIPTION
Deleted duplicated submake that causes warnings.