### PR TITLE
Sound is now disabled automatically if SB16 reset procedure fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,20 @@ If you have sound device issues:
 If you're having issues with no image showing up/QEMU freezing, this is a known bug with QEMU SB16 emulation under GTK. [Please read what @takaswie has written in #2 for a workaround](https://github.com/jdah/tetris-os/issues/2#issuecomment-824773889).
 
 #### Windows
-Absolutely no idea. Maybe try WSL.
+##### Running
+Grab the image file from the releases, and run it with qemu with command `qemu-system-i386 -display sdl -drive format=raw,file=boot.iso -audiodev id=dsound,driver=dsound -device sb16,audiodev=dsound`. This combats the GTK rendering bug with SB16 enabled. If your sound is choppy, try to fiddle with the audio settings, for instance running with `qemu-system-i386 -display sdl -drive format=raw,file=boot.iso -audiodev id=dsound,driver=dsound,out.fixed-settings=on,out.frequency=22050,out.buffer-length=80000,timer-period=100 -device sb16,audiodev=dsound` to increase the audio buffer and set a different timer period for updating the audio. Lowering the sample quality from 44 kHz to 22kHz helps combat choppy audio and buffer underruns with not that much of an audio quality hit.
+
+##### Compiling
+Grab and install [MSYS2](https://www.msys2.org/)  
+Grab and install [i686-elf-tools](https://github.com/lordmilko/i686-elf-tools)    
+* You need to extract the pre-compiled binary archive of i686-elf-tools to your mingw64 folder. Mine was at C:\msys64\mingw64
+* This is for cross-compiling the files to elf binary format, helps a lot to not need to battle with PE format binaries. The makefile uses i386-elf-tools, but this is basically the same thing. The name's different though, so either change the makefile, or make copies of the tools with i386 as the name.
+
+If everything was installed correctly, you should be able to open MSYS2 MINGW64 terminal and from there just do a 
+```
+>make iso
+>qemu-system-i386 boot.iso -display sdl -audiodev id=dsound,driver=dsound -device sb16,audiodev=dsound
+```
 
 #### Real hardware
 You probably know what you're doing if you're going to try this. Just burn `boot.iso` onto some bootable media and give it a go. If things break, try disabling all of the music (remove `#define ENABLE_MUSIC` in `main.c`) since you *probably* don't have something with a SB16 in it.

--- a/src/music.c
+++ b/src/music.c
@@ -303,7 +303,11 @@ static size_t PART_LENGTHS[TRACK_PARTS];
 static i32 indices[TRACK_PARTS];
 static struct NoteActive current[NUM_NOTES];
 
+extern bool sound_enabled;
+
 void music_tick() {
+    if (!sound_enabled) return;
+
     for (size_t i = 0; i < TRACK_PARTS; i++) {
         if (indices[i] == -1 || (current[i].ticks -= 1) <= 0) {
             indices[i] = (indices[i] + 1) % PART_LENGTHS[i];
@@ -325,6 +329,8 @@ void music_tick() {
 }
 
 void music_init() {
+    if (!sound_enabled) return;
+
     sound_wave(0, WAVE_TRIANGLE);
     sound_volume(0, 255);
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -152,6 +152,8 @@ static const f64 NOTES[NUM_OCTAVES * OCTAVE_SIZE] = {
 
 #define BUFFER_SIZE ((size_t) (SAMPLE_RATE * (BUFFER_MS / 1000.0)))
 
+bool sound_enabled = false;
+
 static i16 buffer[BUFFER_SIZE];
 static bool buffer_flip = false;
 
@@ -179,6 +181,8 @@ void sound_wave(u8 index, u8 wave) {
 }
 
 static void fill(i16 *buf, size_t len) {
+    if (!sound_enabled) return;
+
     for (size_t i = 0; i < len; i++) {
         double f = 0.0;
 
@@ -226,11 +230,15 @@ static void fill(i16 *buf, size_t len) {
 }
 
 static void dsp_write(u8 b) {
+    if (!sound_enabled) return;
+
     while (inportb(DSP_WRITE) & 0x80);
     outportb(DSP_WRITE, b);
 }
 
 static void dsp_read(u8 b) {
+    if (!sound_enabled) return;
+
     while (inportb(DSP_READ_STATUS) & 0x80);
     outportb(DSP_READ, b);
 }
@@ -265,21 +273,22 @@ static void reset() {
         goto fail;
     }
 
-    return;
+    sound_enabled = true;
 fail:
-    strlcpy(buf0, "FAILED TO RESET SB16: ", 128);
-    itoa(status, buf1, 128);
-    strlcat(buf0, buf1, 128);
-    panic(buf0);
+    return;
 }
 
 static void set_sample_rate(u16 hz) {
+    if (!sound_enabled) return;
+
     dsp_write(DSP_SET_RATE);
     dsp_write((u8) ((hz >> 8) & 0xFF));
     dsp_write((u8) (hz & 0xFF));
 }
 
 static void transfer(void *buf, u32 len) {
+    if (!sound_enabled) return;
+
     u8 mode = 0x48;
 
     // disable DMA channel
@@ -308,6 +317,8 @@ static void transfer(void *buf, u32 len) {
 }
 
 static void sb16_irq_handler(struct Registers *regs) {
+    if (!sound_enabled) return;
+
     buffer_flip = !buffer_flip;
 
     fill(
@@ -337,6 +348,8 @@ static void configure() {
 void sound_init() {
     irq_install(MIXER_IRQ, sb16_irq_handler);
     reset();
+    if (!sound_enabled) return;
+
     configure();
 
     transfer(buffer, BUFFER_SIZE);

--- a/src/stage0.S
+++ b/src/stage0.S
@@ -27,20 +27,21 @@ _start:
     movw $welcome_str, %si
     call print
 
-    /* read kernel into memory at 0x10000 (segment 0x1000).
-       kernel binary has been placed on the disk directly after the first sector
-       reading $20 * num_sectors sectors after (value in %cx)
-     */
-
     movb $8, %ah
     movb drive_num, %dl
     int $0x13
 
     movb %dh, num_heads
-    andb $1280, %cl
+    andb $0x3f, %cl
     movb %cl, sectors_per_track
 
-    movw $0x3e, %cx
+    /* read kernel into memory at 0x10000 (segment 0x1000).
+       kernel binary has been placed on the disk directly after the first sector
+       How many sectors do we read, value in cx
+       Decimal 1280 is the same as earlier 20 times 0x40 sectors
+     */
+
+    movw $1280, %cx
     movw $0x1000, segment
     movw $0x0000, offset
     movw $1, sector

--- a/src/stage0.S
+++ b/src/stage0.S
@@ -35,27 +35,41 @@ _start:
     movb drive_num, %dl
     movw $disk_packet, %si
     movw $0x1000, segment
-    movw $1, sector
+    movw $2, chs_sector
 sector_loop:
-    movb $0x42, %ah
+    push %cx
+
+    movw segment, %es
+    movb $0x02, %ah
+    movb $1, %al
+    movw chs_sector, %cx
+    movw drive_num, %dx
+    movw offset, %bx
     int $0x13
     jc disk_error
 
-    addw $64, sector
-    addw $0x8000, offset
+    incb chs_sector
+    cmp $18, chs_sector
+    jne sector_same_head_cylinder
+    xorb $1, chs_head
+    jnz sector_same_head_cylinder
+    incb chs_cylinder
+sector_same_head_cylinder:
+    addw $0x0200, offset
     jnc sector_same_segment
 
     /* increment segment, reset offset if on different segment */
     addw $0x1000, segment
     movw $0x0000, offset
 sector_same_segment:
+    pop %cx
     /* decrements %cx and loops if nonzero */
     loop sector_loop
 
     /* video mode: 320x200 @ 16 colors */
     movb $0x00, %ah
     movb $0x13, %al
-    int $0x10
+/*    int $0x10 */
 
     /* enable A20 line */
     cli
@@ -67,7 +81,7 @@ sector_same_segment:
     call enable_a20_wait1
     xorw %ax, %ax
     inb $0x60
-
+    
     /* write new state with A20 bit set (0x2) */
     pushw %ax
     call enable_a20_wait0
@@ -77,11 +91,6 @@ sector_same_segment:
     popw %ax
     orw $0x2, %ax
     outb $0x60
-
-    /* enable PE flag */
-    movl %cr0, %eax
-    orl $0x1, %eax
-    movl %eax, %cr0
 
     /* jmp to flush prefetch queue */
     jmp flush
@@ -97,6 +106,12 @@ flush:
     movw %ax, %gs
     movw %ax, %ss
     movl $0x3000, %esp
+
+    /* enable PE flag */
+    movl %cr0, %eax
+    orl $0x1, %eax
+    movl %eax, %cr0
+
     ljmp $0x8, $entry32
 
 .code32
@@ -126,6 +141,9 @@ enable_a20_wait1:
 disk_error:
     movw $disk_error_str, %si
     call print
+1:
+    jmp 1b
+
 
 /* prints string in %ds:si */
 print:
@@ -145,13 +163,21 @@ print:
 1:  ret
 
 welcome_str:
-    .asciz "TETRIS TIME\n"
+    .asciz "TETRIS TIME\r\n"
 disk_error_str:
-    .asciz "DISK ERROR\n"
+    .asciz "DISK ERROR\r\n"
+debug_str:
+    .asciz "DEBUG\r\n"
 
+chs_sector:
+    .byte 0x01
+chs_cylinder:
+    .byte 0x00
 /* SAVED DRIVE NUMBER TO READ FROM */
 drive_num:
-    .word 0x0000
+    .byte 0x00
+chs_head:
+    .byte 0x00
 
 /* INT 13H PACKET */
 disk_packet:
@@ -197,6 +223,12 @@ gdt_end:
 idt:
     .word 0
     .long 0
+
+debug:
+    movw $debug_str, %si
+    call print
+1:
+    jmp 1b
 
 /* MBR BOOT SIGNATURE */
 .fill 510-(.-_start), 1, 0

--- a/src/stage0.S
+++ b/src/stage0.S
@@ -38,10 +38,9 @@ _start:
     /* read kernel into memory at 0x10000 (segment 0x1000).
        kernel binary has been placed on the disk directly after the first sector
        How many sectors do we read, value in cx
-       Decimal 1280 is the same as earlier 20 times 0x40 sectors
      */
 
-    movw $1280, %cx
+    movw $0x40, %cx
     movw $0x1000, segment
     movw $0x0000, offset
     movw $1, sector

--- a/src/stage0.S
+++ b/src/stage0.S
@@ -31,6 +31,14 @@ _start:
        kernel binary has been placed on the disk directly after the first sector
        reading $20 * num_sectors sectors after (value in %cx)
      */
+
+    push %ax
+    push %bx
+    push %cx
+    push %dx
+    push %es
+    push %si
+
     movw $20, %cx
     movb drive_num, %dl
     movw $disk_packet, %si
@@ -42,15 +50,17 @@ sector_loop:
     movw segment, %es
     movb $0x02, %ah
     movb $1, %al
-    movw chs_sector, %cx
+    movb chs_cylinder, %ch
+    movb chs_sector, %cl
     movw drive_num, %dx
     movw offset, %bx
     int $0x13
     jc disk_error
 
     incb chs_sector
-    cmp $18, chs_sector
+    cmp $19, chs_sector
     jne sector_same_head_cylinder
+    movb $1, chs_sector
     xorb $1, chs_head
     jnz sector_same_head_cylinder
     incb chs_cylinder
@@ -66,10 +76,17 @@ sector_same_segment:
     /* decrements %cx and loops if nonzero */
     loop sector_loop
 
+    pop %si
+    pop %es
+    pop %dx
+    pop %cx
+    pop %bx
+    pop %ax
+
     /* video mode: 320x200 @ 16 colors */
     movb $0x00, %ah
     movb $0x13, %al
-/*    int $0x10 */
+    int $0x10 
 
     /* enable A20 line */
     cli
@@ -92,6 +109,11 @@ sector_same_segment:
     orw $0x2, %ax
     outb $0x60
 
+    /* enable PE flag */
+    movl %cr0, %eax
+    orl $0x1, %eax
+    movl %eax, %cr0
+    
     /* jmp to flush prefetch queue */
     jmp flush
 flush:
@@ -106,11 +128,6 @@ flush:
     movw %ax, %gs
     movw %ax, %ss
     movl $0x3000, %esp
-
-    /* enable PE flag */
-    movl %cr0, %eax
-    orl $0x1, %eax
-    movl %eax, %cr0
 
     ljmp $0x8, $entry32
 

--- a/src/stage0.S
+++ b/src/stage0.S
@@ -19,7 +19,8 @@ _start:
     movw $0x3000, %sp
 
     /* save drive number to read kernel later */
-    mov %dl, drive_num
+    movw $drive_num, %si
+    mov %dl, (%si)
 
     sti
 
@@ -32,40 +33,61 @@ _start:
        reading $20 * num_sectors sectors after (value in %cx)
      */
 
-    push %ax
-    push %bx
-    push %cx
-    push %dx
-    push %es
-    push %si
-
-    movw $20, %cx
+    movb $8, %ah
     movb drive_num, %dl
-    movw $disk_packet, %si
+    int $0x13
+
+    movb %dh, num_heads
+    andb $1280, %cl
+    movb %cl, sectors_per_track
+
+    movw $0x3e, %cx
     movw $0x1000, segment
+    movw $0x0000, offset
+    movw $1, sector
     movw $2, chs_sector
 sector_loop:
     push %cx
 
-    movw segment, %es
+    movb $0x42, %ah
+    movb drive_num, %dl
+    movw $disk_packet, %si
+    int $0x13
+    jnc disk_success
+
     movb $0x02, %ah
-    movb $1, %al
+    movb $1, %al /* Read 1 sector */
     movb chs_cylinder, %ch
     movb chs_sector, %cl
-    movw drive_num, %dx
+    movb drive_num, %dl
+    movb chs_head, %dh
+    movw segment, %es
     movw offset, %bx
     int $0x13
     jc disk_error
 
+disk_success:
+    incb sector
+/* increase sectors, and check for track limit */
     incb chs_sector
-    cmp $19, chs_sector
-    jne sector_same_head_cylinder
+    
+    movb sectors_per_track, %al
+    cmp %al, chs_sector
+    jna sector_same_head_cylinder
+
+/* sectors per track exceeded, reset sector to 1, increase heads and check for head limit */
     movb $1, chs_sector
-    xorb $1, chs_head
-    jnz sector_same_head_cylinder
+    incb chs_head
+    mov num_heads, %al
+    cmp %al, chs_head
+    jna sector_same_head_cylinder
+
+/* head count exceeded, reset head to 0, increase cylinder */
+    movb $0, chs_head
     incb chs_cylinder
+
 sector_same_head_cylinder:
-    addw $0x0200, offset
+    addw $0x200, offset /* we read a single 512 sector, so increase our offset by 0x200 (512) */
     jnc sector_same_segment
 
     /* increment segment, reset offset if on different segment */
@@ -75,13 +97,6 @@ sector_same_segment:
     pop %cx
     /* decrements %cx and loops if nonzero */
     loop sector_loop
-
-    pop %si
-    pop %es
-    pop %dx
-    pop %cx
-    pop %bx
-    pop %ax
 
     /* video mode: 320x200 @ 16 colors */
     movb $0x00, %ah
@@ -128,7 +143,7 @@ flush:
     movw %ax, %gs
     movw %ax, %ss
     movl $0x3000, %esp
-
+    
     ljmp $0x8, $entry32
 
 .code32
@@ -196,12 +211,19 @@ drive_num:
 chs_head:
     .byte 0x00
 
+marker:
+    .byte 0xde,0xad,0xbe,0xef
+num_heads:
+    .byte 0x00
+sectors_per_track:
+    .byte 0x00
+
 /* INT 13H PACKET */
 disk_packet:
     .byte 0x10
     .byte 0x00
 num_sectors:
-    .word 0x0040
+    .word 0x0001
 offset:
     .word 0x0000
 segment:

--- a/src/stage0.S
+++ b/src/stage0.S
@@ -19,8 +19,7 @@ _start:
     movw $0x3000, %sp
 
     /* save drive number to read kernel later */
-    movw $drive_num, %si
-    mov %dl, (%si)
+    mov %dl, drive_num
 
     sti
 


### PR DESCRIPTION
No need to use compile-time defines. 