### PR TITLE
Use CRLF instead of LF for printing greeting/error messages

### DIFF
--- a/src/stage0.S
+++ b/src/stage0.S
@@ -145,9 +145,9 @@ print:
 1:  ret
 
 welcome_str:
-    .asciz "TETRIS TIME\n"
+    .asciz "TETRIS TIME\r\n"
 disk_error_str:
-    .asciz "DISK ERROR\n"
+    .asciz "DISK ERROR\r\n"
 
 /* SAVED DRIVE NUMBER TO READ FROM */
 drive_num:


### PR DESCRIPTION
Carriage Return is necessary since, on a "bare" terminal, LineFeed
does not return the cursor to the beginning of the line. Therefore,
printed lines will look "slanted".