### PR TITLE
Disable SB16 dynamically

### DIFF
--- a/src/music.c
+++ b/src/music.c
@@ -303,7 +303,11 @@ static size_t PART_LENGTHS[TRACK_PARTS];
 static i32 indices[TRACK_PARTS];
 static struct NoteActive current[NUM_NOTES];
 
+extern bool sound_enabled;
+
 void music_tick() {
+    if (!sound_enabled) return;
+
     for (size_t i = 0; i < TRACK_PARTS; i++) {
         if (indices[i] == -1 || (current[i].ticks -= 1) <= 0) {
             indices[i] = (indices[i] + 1) % PART_LENGTHS[i];
@@ -325,6 +329,8 @@ void music_tick() {
 }
 
 void music_init() {
+    if (!sound_enabled) return;
+
     sound_wave(0, WAVE_TRIANGLE);
     sound_volume(0, 255);
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -152,6 +152,8 @@ static const f64 NOTES[NUM_OCTAVES * OCTAVE_SIZE] = {
 
 #define BUFFER_SIZE ((size_t) (SAMPLE_RATE * (BUFFER_MS / 1000.0)))
 
+bool sound_enabled = false;
+
 static i16 buffer[BUFFER_SIZE];
 static bool buffer_flip = false;
 
@@ -179,6 +181,8 @@ void sound_wave(u8 index, u8 wave) {
 }
 
 static void fill(i16 *buf, size_t len) {
+    if (!sound_enabled) return;
+
     for (size_t i = 0; i < len; i++) {
         double f = 0.0;
 
@@ -226,11 +230,15 @@ static void fill(i16 *buf, size_t len) {
 }
 
 static void dsp_write(u8 b) {
+    if (!sound_enabled) return;
+
     while (inportb(DSP_WRITE) & 0x80);
     outportb(DSP_WRITE, b);
 }
 
 static void dsp_read(u8 b) {
+    if (!sound_enabled) return;
+
     while (inportb(DSP_READ_STATUS) & 0x80);
     outportb(DSP_READ, b);
 }
@@ -265,21 +273,22 @@ static void reset() {
         goto fail;
     }
 
-    return;
+    sound_enabled = true;
 fail:
-    strlcpy(buf0, "FAILED TO RESET SB16: ", 128);
-    itoa(status, buf1, 128);
-    strlcat(buf0, buf1, 128);
-    panic(buf0);
+    return;
 }
 
 static void set_sample_rate(u16 hz) {
+    if (!sound_enabled) return;
+
     dsp_write(DSP_SET_RATE);
     dsp_write((u8) ((hz >> 8) & 0xFF));
     dsp_write((u8) (hz & 0xFF));
 }
 
 static void transfer(void *buf, u32 len) {
+    if (!sound_enabled) return;
+
     u8 mode = 0x48;
 
     // disable DMA channel
@@ -308,6 +317,8 @@ static void transfer(void *buf, u32 len) {
 }
 
 static void sb16_irq_handler(struct Registers *regs) {
+    if (!sound_enabled) return;
+
     buffer_flip = !buffer_flip;
 
     fill(
@@ -337,6 +348,8 @@ static void configure() {
 void sound_init() {
     irq_install(MIXER_IRQ, sb16_irq_handler);
     reset();
+    if (!sound_enabled) return;
+
     configure();
 
     transfer(buffer, BUFFER_SIZE);


### PR DESCRIPTION
This way the same binaries can be run in systems with or without SB16. Compile directives can still be used to disable music completely in case there are still some music related problems and the dynamic disable doesn't sense the presence of SB16 correctly.