### PR TITLE
PC Speaker music (requires Dynamic SB16)

### DIFF
--- a/src/music.c
+++ b/src/music.c
@@ -2,6 +2,7 @@
 #include "timer.h"
 #include "sound.h"
 #include "math.h"
+#include "speaker.h"
 
 struct Note {
     u8 octave;
@@ -306,8 +307,6 @@ static struct NoteActive current[NUM_NOTES];
 extern bool sound_enabled;
 
 void music_tick() {
-    if (!sound_enabled) return;
-
     for (size_t i = 0; i < TRACK_PARTS; i++) {
         if (indices[i] == -1 || (current[i].ticks -= 1) <= 0) {
             indices[i] = (indices[i] + 1) % PART_LENGTHS[i];
@@ -318,19 +317,31 @@ void music_tick() {
             current[i].note = note;
             current[i].ticks = TICKS_PER_SIXTEENTH * note.duration - remainder;
 
-            sound_note(i, note.octave, note.note);
+            if (sound_enabled)
+            {
+                sound_note(i, note.octave, note.note);
+            }
+            else if (i == 0)
+            {
+                speaker_note(note.octave, note.note);
+            }
         }
 
         // remove last tick to give each note an attack
         if (current[i].ticks <= 1) {
-            sound_note(i, OCTAVE_1, NOTE_NONE);
+            if (sound_enabled)
+            {
+                sound_note(i, OCTAVE_1, NOTE_NONE);
+            } 
+            else if (i == 0)
+            {
+                speaker_note(0, NOTE_NONE);
+            }
         }
     }
 }
 
 void music_init() {
-    if (!sound_enabled) return;
-
     sound_wave(0, WAVE_TRIANGLE);
     sound_volume(0, 255);
 

--- a/src/music.c
+++ b/src/music.c
@@ -303,7 +303,11 @@ static size_t PART_LENGTHS[TRACK_PARTS];
 static i32 indices[TRACK_PARTS];
 static struct NoteActive current[NUM_NOTES];
 
+extern bool sound_enabled;
+
 void music_tick() {
+    if (!sound_enabled) return;
+
     for (size_t i = 0; i < TRACK_PARTS; i++) {
         if (indices[i] == -1 || (current[i].ticks -= 1) <= 0) {
             indices[i] = (indices[i] + 1) % PART_LENGTHS[i];
@@ -325,6 +329,8 @@ void music_tick() {
 }
 
 void music_init() {
+    if (!sound_enabled) return;
+
     sound_wave(0, WAVE_TRIANGLE);
     sound_volume(0, 255);
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -152,6 +152,8 @@ static const f64 NOTES[NUM_OCTAVES * OCTAVE_SIZE] = {
 
 #define BUFFER_SIZE ((size_t) (SAMPLE_RATE * (BUFFER_MS / 1000.0)))
 
+bool sound_enabled = false;
+
 static i16 buffer[BUFFER_SIZE];
 static bool buffer_flip = false;
 
@@ -179,6 +181,8 @@ void sound_wave(u8 index, u8 wave) {
 }
 
 static void fill(i16 *buf, size_t len) {
+    if (!sound_enabled) return;
+
     for (size_t i = 0; i < len; i++) {
         double f = 0.0;
 
@@ -226,11 +230,15 @@ static void fill(i16 *buf, size_t len) {
 }
 
 static void dsp_write(u8 b) {
+    if (!sound_enabled) return;
+
     while (inportb(DSP_WRITE) & 0x80);
     outportb(DSP_WRITE, b);
 }
 
 static void dsp_read(u8 b) {
+    if (!sound_enabled) return;
+
     while (inportb(DSP_READ_STATUS) & 0x80);
     outportb(DSP_READ, b);
 }
@@ -265,21 +273,22 @@ static void reset() {
         goto fail;
     }
 
-    return;
+    sound_enabled = true;
 fail:
-    strlcpy(buf0, "FAILED TO RESET SB16: ", 128);
-    itoa(status, buf1, 128);
-    strlcat(buf0, buf1, 128);
-    panic(buf0);
+    return;
 }
 
 static void set_sample_rate(u16 hz) {
+    if (!sound_enabled) return;
+
     dsp_write(DSP_SET_RATE);
     dsp_write((u8) ((hz >> 8) & 0xFF));
     dsp_write((u8) (hz & 0xFF));
 }
 
 static void transfer(void *buf, u32 len) {
+    if (!sound_enabled) return;
+
     u8 mode = 0x48;
 
     // disable DMA channel
@@ -308,6 +317,8 @@ static void transfer(void *buf, u32 len) {
 }
 
 static void sb16_irq_handler(struct Registers *regs) {
+    if (!sound_enabled) return;
+
     buffer_flip = !buffer_flip;
 
     fill(
@@ -337,6 +348,8 @@ static void configure() {
 void sound_init() {
     irq_install(MIXER_IRQ, sb16_irq_handler);
     reset();
+    if (!sound_enabled) return;
+
     configure();
 
     transfer(buffer, BUFFER_SIZE);

--- a/src/speaker.c
+++ b/src/speaker.c
@@ -1,44 +1,58 @@
 #include "speaker.h"
-#include "fpu.h"
+
+#define NOTE_NONE 12
 
 // SEE: https://wiki.osdev.org/PC_Speaker
 // SEE ALSO: https://web.archive.org/web/20171115162742/http://guideme.itgo.com/atozofc/ch23.pdf
+// Precalculated LUT table for notes
 
-static float notes[7][12] = {
-    { 130.81, 138.59, 146.83, 155.56, 164.81, 174.61, 185.0,
-        196.0, 207.65, 220.0, 227.31, 246.96 },
-    { 261.63, 277.18, 293.66, 311.13, 329.63, 349.23, 369.63,
-        392.0, 415.3, 440.0, 454.62, 493.92 },
-    { 523.25, 554.37, 587.33, 622.25, 659.26, 698.46, 739.99,
-        783.99, 830.61, 880.0, 909.24, 987.84 },
-    { 1046.5, 1108.73, 1174.66, 1244.51, 1328.51, 1396.91, 1479.98,
-        1567.98, 1661.22, 1760.0, 1818.48, 1975.68 },
-    { 2093.0, 2217.46, 2349.32, 2489.02, 2637.02, 2793.83, 2959.96,
-        3135.96, 3322.44, 3520.0, 3636.96, 3951.36 },
-    { 4186.0, 4434.92, 4698.64, 4978.04, 5274.04, 5587.86, 5919.92,
-        6271.92, 6644.88, 7040.0, 7273.92, 7902.72 },
-    { 8372.0, 8869.89, 9397.28,9956.08,10548.08,11175.32, 11839.84,
-        12543.84, 13289.76, 14080.0, 14547.84, 15805.44 }
+static u16 notes[7][12] = {
+    { 36485, 34437, 32505, 30680, 28958, 27333, 25799, 24351, 22984, 21694, 20477, 19327 },
+    { 18243, 17219, 16252, 15340, 14479, 13666, 12899, 12175, 11492, 10847, 10238, 9664 },
+    { 9121, 8609, 8126, 7670, 7240, 6833, 6450, 6088, 5746, 5424, 5119, 4832 },
+    { 4561, 4305, 4063, 3835, 3620, 3417, 3225, 3044, 2873, 2712, 2560, 2416 }, 
+    { 2280, 2152, 2032, 1918, 1810, 1708, 1612, 1522, 1437, 1356, 1280, 1208 },
+    { 1140, 1076, 1016, 959, 905, 854, 806, 761, 718, 678, 640, 604},
+    { 570, 538, 508, 479, 452, 427, 403, 380, 359, 339, 320, 302 }
 };
 
+bool note_playing = false;
+u8 current_note = NOTE_NONE;
+u8 current_octave = 0;
+
 void speaker_note(u8 octave, u8 note) {
-    speaker_play((u32) notes[octave][note]);
+    if (octave == current_octave && note == current_note)
+        return;
+
+    current_octave = octave;
+    current_note = note;
+    
+    if (note == NOTE_NONE)
+    {
+        speaker_pause();
+
+        return;
+    }
+
+    speaker_play(notes[octave][note]);
 }
 
-void speaker_play(u32 hz) {
-    u32 d = 1193180 / hz;
+void speaker_play(u16 d) {
     outportb(0x43, 0xB6);
-    //outportb(0x42, (u8) (d & 0xFF));
-    //outportb(0x42, (u8) ((d >> 8) & 0xFF));
-    outportb(0x42, 140);
-    outportb(0x42, 140);
+    outportb(0x42, (u8) (d & 0xFF));
+    outportb(0x42, (u8) ((d >> 8) & 0xFF));
 
-    u8 t = inportb(0x61);
-    if (t != (t | 0x3)) {
-        outportb(0x61, t | 0x3);
+    // If there already is a note playing, re-enabling it just makes the timer start over - thus it gets choppy. 
+    // By just changing the frequency when the speaker output is already enabled, we can change frequencys without any choppyness penalty
+    if (!note_playing)
+    {
+        note_playing = true;
+        outportb(0x61, inportb(0x61) | 0x3);
     }
 }
 
 void speaker_pause() {
+    note_playing = false;
+
     outportb(0x61, inportb(0x61) & 0xFC);
 }

--- a/src/speaker.h
+++ b/src/speaker.h
@@ -4,7 +4,7 @@
 #include "util.h"
 
 void speaker_note(u8 octave, u8 note);
-void speaker_play(u32 hz);
+void speaker_play(u16 d);
 void speaker_pause();
 
 #endif


### PR DESCRIPTION
Managed to fix the simple PC Speaker note playing. The original had too high frequency values regarding the music, and also some commented out code. Changed the note look-up table to a u16 table that gets straight up fed to the PIT. Also, checking for an enabled note is changed to a variable instead of accessing HW ports. Also added some logic to not bother setting notes if they were already set as the same ones.

The PC Speaker notes play the MELODY track, and do so only if SB16 is not found. Works at least in QEMU with switches ` -audiodev id=dsound,driver=dsound -machine pcspk-audiodev=dsound` Couldn't get to work on real hardware, but I'm not sure if any of my PC's have the speaker installed anymore. I was sure I fairly recently saw one lying around somewhere by itself, but now I can't find it and install to test. But works in QEMU!

EDIT: Added a release in my fork with all my current changes including the PC Speaker music https://github.com/zment4/tetris-os/releases/pcspkr_v1

EDIT2: Realized I hadn't tested the build on my main computer, which incidentally seems to be the only one still having an onboard PC buzzer. I'm glad to report that PC Speaker code works very well on real hardware!

