### PR TITLE
removed duplicate line in bootloader

### DIFF
--- a/src/stage0.S
+++ b/src/stage0.S
@@ -142,7 +142,6 @@ flush:
     movw $(gdt_data_segment - gdt_start), %ax
     movw %ax, %ds
     movw %ax, %es
-    movw %ax, %es
     movw %ax, %fs
     movw %ax, %gs
     movw %ax, %ss


### PR DESCRIPTION
This removes the duplicate line

```
movw %ax, %es
```

in the bootloader `stage0.S` under `flush` when setting up the data selectors.

I don't think this line is needed twice.